### PR TITLE
Add PCP support to the wrapper

### DIFF
--- a/io_burst/burst_io.sh
+++ b/io_burst/burst_io.sh
@@ -387,6 +387,6 @@ fi
 echo $results >> test_results_report
 tar cf /tmp/${results_file}.tar $results_file
 
-${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root  --test_name $test_name --tuned_setting $to_tuned_setting --version $burst_io_version --user $to_user --results $results_file --other_files test_results_report
+${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root  --test_name $test_name --tuned_setting $to_tuned_setting --version $burst_io_version --user $to_user --results $results_file --other_files test_results_report,${pcpdir}
 
 exit 0


### PR DESCRIPTION
# Description
This enables PCP support in the wrapper. Test runs have resulted in PCP archives being created and saved alongside test results

# Before/After Comparison
Before: No PCP support in the wrapper
After: PCP support in the wrapper

# Clerical Stuff
This closes #12 
Relates to JIRA: RPOPC-598
