### PR TITLE
Add package manangement to wrapper

### DIFF
--- a/io_burst/burst_io.sh
+++ b/io_burst/burst_io.sh
@@ -332,7 +332,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Install needed packages based on what's listed in the wrapper's json file
-${TOOLS_BIN}/package_tool ---no_packages $to_no_pkg_install -wrapper_config ${run_dir}/io_burst-wrapper.json
+${TOOLS_BIN}/package_tool --no_packages $to_no_pkg_install -wrapper_config ${run_dir}/io_burst-wrapper.json
 if [[ $? -ne 0 ]]; then
         exit_out "package_tool reported failure installing dependencies." 1
 fi

--- a/io_burst/burst_io.sh
+++ b/io_burst/burst_io.sh
@@ -332,7 +332,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Install needed packages based on what's listed in the wrapper's json file
-${TOOLS_BIN}/package_tool --no_packages $to_no_pkg_install -wrapper_config ${run_dir}/io_burst-wrapper.json
+${TOOLS_BIN}/package_tool --no_packages $to_no_pkg_install --wrapper_config ${run_dir}/io_burst-wrapper.json
 if [[ $? -ne 0 ]]; then
         exit_out "package_tool reported failure installing dependencies." 1
 fi

--- a/io_burst/burst_io.sh
+++ b/io_burst/burst_io.sh
@@ -332,7 +332,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Install needed packages based on what's listed in the wrapper's json file
-${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/io_burst-wrapper.json
+${TOOLS_BIN}/package_tool ---no_packages $to_no_pkg_install -wrapper_config ${run_dir}/io_burst-wrapper.json
 if [[ $? -ne 0 ]]; then
         exit_out "package_tool reported failure installing dependencies." 1
 fi

--- a/io_burst/burst_io.sh
+++ b/io_burst/burst_io.sh
@@ -330,6 +330,10 @@ while [[ $# -gt 0 ]]; do
 		;;
         esac
 done
+
+# Install needed packages based on what's listed in the wrapper's json file
+${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/io_burst-wrapper.json
+
 #
 # Get the disk size if present.
 #

--- a/io_burst/burst_io.sh
+++ b/io_burst/burst_io.sh
@@ -333,6 +333,9 @@ done
 
 # Install needed packages based on what's listed in the wrapper's json file
 ${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/io_burst-wrapper.json
+if [[ $? -ne 0 ]]; then
+        exit_out "package_tool reported failure installing dependencies." 1
+fi
 
 #
 # Get the disk size if present.

--- a/io_burst/io_burst-wrapper.json
+++ b/io_burst/io_burst-wrapper.json
@@ -1,0 +1,27 @@
+{
+  "dependencies": {
+    "rhel": [
+      "bc",
+      "gcc",
+      "git",
+      "make",
+      "perf",
+      "unzip",
+      "zip",
+      "pcp-zeroconf",
+      "pcp-pmda-openmetrics",
+      "pcp-pmda-denki"
+    ],
+    "ubuntu": [
+      "bc",
+      "gcc",
+      "git",
+      "make",
+      "linux-tools-generic",
+      "unzip",
+      "zip",
+      "pcp-zeroconf"
+    ]
+  }
+}
+


### PR DESCRIPTION
# Description
This adds handling of package dependencies to the wrapper based on what's in the wrapper's json file, and adds said json file.

# Before/After Comparison
Before: packages are installed by the parent harness
After: packages are installed by the wrapper based on contents of associated json file.
I watched the sequence work properly on rhel and ubuntu

# Clerical Stuff
This closes #15 

Relates to JIRA: RPOPC-648
